### PR TITLE
eslintエラー解消

### DIFF
--- a/react-native-app/babel.config.js
+++ b/react-native-app/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function (api) {
+module.exports = function fn(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],


### PR DESCRIPTION
babel.config.jsで関数名がないというeslintエラーが出ていたため、適当な関数名を付与して解消